### PR TITLE
Changes Eloquent from getSingle()

### DIFF
--- a/backend/app/Http/Controllers/EventController.php
+++ b/backend/app/Http/Controllers/EventController.php
@@ -88,7 +88,7 @@ class EventController extends Controller
 
     public function getSingle($id)
     {
-        return Event::where('id', $id)->with('airports.sceneries')->get();  //Returns a single Event from the database
+        return Event::where('id', $id)->with('airports.sceneries')->first();  //Returns a single Event from the database
     }
 
     public function update(Request $request, $id)


### PR DESCRIPTION
Changes the Eloquent syntax from the `getSingle()` function from `get()`, to `first()`, so it returns a regular multi-level array.

This was a "bug" (not actually a bug, but can cause inconveniences onto the frontend) introduced on #48.