### PR TITLE
[PLEASE TEST] Special case on departures and arrivals plurals

### DIFF
--- a/src/i18n/locales/en-us.ts
+++ b/src/i18n/locales/en-us.ts
@@ -76,8 +76,10 @@ const ptBrTranslations: { translations: Translations } = {
     },
     flights: {
       search: 'Search Flights',
+      arrival_zero: 'Nenhuma chegada',
       arrival_one: 'Arrival',
       arrival_other: 'Arrivals',
+      departure_zero: 'Nenhuma partida',
       departure_one: 'Departure',
       departure_other: 'Departures',
       privateSlots: 'Private Slots',

--- a/src/i18n/locales/pt-br.ts
+++ b/src/i18n/locales/pt-br.ts
@@ -76,8 +76,10 @@ const ptBrTranslations: { translations: Translations } = {
     },
     flights: {
       search: 'Buscar voo',
+      arrival_zero: 'Nenhuma chegada',
       arrival_one: 'Chegada',
       arrival_other: 'Chegadas',
+      departure_zero: 'Nenhuma saída',
       departure_one: 'Partida',
       departure_other: 'Partidas',
       privateSlots: 'Slots Privados',

--- a/src/types/Translations.ts
+++ b/src/types/Translations.ts
@@ -75,8 +75,10 @@ export interface Translations {
   },
   flights: {
     search: string,
+    arrival_zero: string, 
     arrival_one: string,
     arrival_other: string,
+    departure_zero: string,
     departure_one: string,
     departure_other: string,
     privateSlots: string,


### PR DESCRIPTION
This SHOULD fix the special cases on `flights.departure` and `flights.arrival` translations, whenever these counts equal zero. 

Please, update this as last to stage, so we can test. My local environment is not running well and I have not been able to test this.